### PR TITLE
Webpack 2 Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ ExternalsPlugin.prototype.apply = function(compiler) {
           }
           if (ModuleFilenameHelpers.matchObject(opts, module.resource)) {
             return callback(null, new ExternalModule(
-              data.dependency.request,
+              data.request,
               opts.type || compiler.options.output.libraryTarget
             ));
           }


### PR DESCRIPTION
This makes it work with Webpack 2.
Linked to #1 

_Update:_
Created https://github.com/tomasAlabes/webpack2-externals-plugin for this, that works on Webpack 2+.